### PR TITLE
Add new parameter to allow running tests with custom runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ your project.
 
 ~~~
 usage: unittest-parallel [-h] [-v] [-q] [-f] [-b] [-k TESTNAMEPATTERNS]
-                         [-s START] [-p PATTERN] [-t TOP] [-j COUNT]
+                         [-s START] [-p PATTERN] [-t TOP] [-j COUNT] [-r RUNNER]
                          [--level {module,class,test}]
                          [--disable-process-pooling] [--coverage]
                          [--coverage-branch] [--coverage-rcfile RCFILE]
@@ -79,6 +79,9 @@ options:
   -t TOP, --top-level-directory TOP
                         Top level directory of project (defaults to start
                         directory)
+  -r RUNNER, --runner RUNNER
+                        Custom unittest runner module and class (Supported: TeamCity)
+                        E.g.: `-r teamcity.unittestpy TeamcityTestRunner
 
 parallelization options:
   -j COUNT, --jobs COUNT

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ package_dir =
     = src
 install_requires =
     coverage >= 5.1
+    teamcity-messages == 1.32
 
 [options.entry_points]
 console_scripts =

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -1607,3 +1607,51 @@ OK
 
 Total coverage is 100.00%
 ''')
+
+    
+    def test_invalid_custom_runner(self):
+        discover_suite = unittest.TestSuite(tests=[
+            unittest.TestSuite(tests=[
+                unittest.TestSuite(tests=[SuccessTestCase('mock_1'), SuccessTestCase('mock_2'), SuccessTestCase('mock_3')]),
+            ])
+        ])
+        with patch('multiprocessing.cpu_count', Mock(return_value=2)), \
+             patch('multiprocessing.get_context', new=MockMultiprocessingContext), \
+             patch('multiprocessing.Manager', new=MockMultiprocessingManager), \
+             patch('sys.stdout', StringIO()) as stdout, \
+             patch('sys.stderr', StringIO()) as stderr, \
+             patch('unittest.TestLoader.discover', Mock(return_value=discover_suite)):
+            with self.assertRaises(ModuleNotFoundError):
+                main(['-v', '--runner', 'invalid_method', 'InvalidClass'])
+    
+    def test_teamcity_custom_runner(self):
+        discover_suite = unittest.TestSuite(tests=[
+            unittest.TestSuite(tests=[
+                unittest.TestSuite(tests=[SuccessTestCase('mock_1'), SuccessTestCase('mock_2'), SuccessTestCase('mock_3')]),
+            ])
+        ])
+        with patch('multiprocessing.cpu_count', Mock(return_value=2)), \
+             patch('multiprocessing.get_context', new=MockMultiprocessingContext), \
+             patch('multiprocessing.Manager', new=MockMultiprocessingManager), \
+             patch('sys.stdout', StringIO()) as stdout, \
+             patch('sys.stderr', StringIO()) as stderr, \
+             patch('unittest.TestLoader.discover', Mock(return_value=discover_suite)):
+            main(['-v', '--runner', 'teamcity.unittestpy', 'TeamcityTestRunner'])
+
+        self.assertEqual(stdout.getvalue(), '')
+
+    def test_unittest_custom_runner_as_param(self):
+        discover_suite = unittest.TestSuite(tests=[
+            unittest.TestSuite(tests=[
+                unittest.TestSuite(tests=[SuccessTestCase('mock_1'), SuccessTestCase('mock_2'), SuccessTestCase('mock_3')]),
+            ])
+        ])
+        with patch('multiprocessing.cpu_count', Mock(return_value=2)), \
+             patch('multiprocessing.get_context', new=MockMultiprocessingContext), \
+             patch('multiprocessing.Manager', new=MockMultiprocessingManager), \
+             patch('sys.stdout', StringIO()) as stdout, \
+             patch('sys.stderr', StringIO()) as stderr, \
+             patch('unittest.TestLoader.discover', Mock(return_value=discover_suite)):
+            main(['-v', '--runner', 'unittest', 'TextTestRunner'])
+
+        self.assertEqual(stdout.getvalue(), '')

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -1612,7 +1612,7 @@ Total coverage is 100.00%
     def test_invalid_custom_runner(self):
         discover_suite = unittest.TestSuite(tests=[
             unittest.TestSuite(tests=[
-                unittest.TestSuite(tests=[SuccessTestCase('mock_1'), SuccessTestCase('mock_2'), SuccessTestCase('mock_3')]),
+                unittest.TestSuite(tests=[SuccessTestCase('mock_1')]),
             ])
         ])
         with patch('multiprocessing.cpu_count', Mock(return_value=2)), \
@@ -1627,7 +1627,7 @@ Total coverage is 100.00%
     def test_teamcity_custom_runner(self):
         discover_suite = unittest.TestSuite(tests=[
             unittest.TestSuite(tests=[
-                unittest.TestSuite(tests=[SuccessTestCase('mock_1'), SuccessTestCase('mock_2'), SuccessTestCase('mock_3')]),
+                unittest.TestSuite(tests=[SuccessTestCase('mock_1'), SuccessTestCase('mock_2'), SuccessTestCase('mock_3')])
             ])
         ])
         with patch('multiprocessing.cpu_count', Mock(return_value=2)), \
@@ -1639,11 +1639,43 @@ Total coverage is 100.00%
             main(['-v', '--runner', 'teamcity.unittestpy', 'TeamcityTestRunner'])
 
         self.assertEqual(stdout.getvalue(), '')
+        if sys.version_info < (3, 11): # pragma: no cover
+            self.assertEqual(re.sub(r'\d+\.\d{3}s', '<SEC>s', stderr.getvalue()), '''\
+Running 1 test suites (3 total tests) across 1 processes
+
+mock_1 (tests.test_main.SuccessTestCase) ...
+mock_1 (tests.test_main.SuccessTestCase) ... ok
+mock_2 (tests.test_main.SuccessTestCase) ...
+mock_2 (tests.test_main.SuccessTestCase) ... ok
+mock_3 (tests.test_main.SuccessTestCase) ...
+mock_3 (tests.test_main.SuccessTestCase) ... ok
+
+----------------------------------------------------------------------
+Ran 3 tests in <SEC>s
+
+OK
+''')
+        else: # pragma: no cover
+            self.assertEqual(re.sub(r'\d+\.\d{3}s', '<SEC>s', stderr.getvalue()), '''\
+Running 1 test suites (3 total tests) across 1 processes
+
+mock_1 (tests.test_main.SuccessTestCase.mock_1) ...
+mock_1 (tests.test_main.SuccessTestCase.mock_1) ... ok
+mock_2 (tests.test_main.SuccessTestCase.mock_2) ...
+mock_2 (tests.test_main.SuccessTestCase.mock_2) ... ok
+mock_3 (tests.test_main.SuccessTestCase.mock_3) ...
+mock_3 (tests.test_main.SuccessTestCase.mock_3) ... ok
+
+----------------------------------------------------------------------
+Ran 3 tests in <SEC>s
+
+OK
+''')
 
     def test_unittest_custom_runner_as_param(self):
         discover_suite = unittest.TestSuite(tests=[
             unittest.TestSuite(tests=[
-                unittest.TestSuite(tests=[SuccessTestCase('mock_1'), SuccessTestCase('mock_2'), SuccessTestCase('mock_3')]),
+                unittest.TestSuite(tests=[SuccessTestCase('mock_1'), SuccessTestCase('mock_2'), SuccessTestCase('mock_3')])
             ])
         ])
         with patch('multiprocessing.cpu_count', Mock(return_value=2)), \
@@ -1655,3 +1687,35 @@ Total coverage is 100.00%
             main(['-v', '--runner', 'unittest', 'TextTestRunner'])
 
         self.assertEqual(stdout.getvalue(), '')
+        if sys.version_info < (3, 11): # pragma: no cover
+            self.assertEqual(re.sub(r'\d+\.\d{3}s', '<SEC>s', stderr.getvalue()), '''\
+Running 1 test suites (3 total tests) across 1 processes
+
+mock_1 (tests.test_main.SuccessTestCase) ...
+mock_1 (tests.test_main.SuccessTestCase) ... ok
+mock_2 (tests.test_main.SuccessTestCase) ...
+mock_2 (tests.test_main.SuccessTestCase) ... ok
+mock_3 (tests.test_main.SuccessTestCase) ...
+mock_3 (tests.test_main.SuccessTestCase) ... ok
+
+----------------------------------------------------------------------
+Ran 3 tests in <SEC>s
+
+OK
+''')
+        else: # pragma: no cover
+            self.assertEqual(re.sub(r'\d+\.\d{3}s', '<SEC>s', stderr.getvalue()), '''\
+Running 1 test suites (3 total tests) across 1 processes
+
+mock_1 (tests.test_main.SuccessTestCase.mock_1) ...
+mock_1 (tests.test_main.SuccessTestCase.mock_1) ... ok
+mock_2 (tests.test_main.SuccessTestCase.mock_2) ...
+mock_2 (tests.test_main.SuccessTestCase.mock_2) ... ok
+mock_3 (tests.test_main.SuccessTestCase.mock_3) ...
+mock_3 (tests.test_main.SuccessTestCase.mock_3) ... ok
+
+----------------------------------------------------------------------
+Ran 3 tests in <SEC>s
+
+OK
+''')

--- a/src/unittest_parallel/main.py
+++ b/src/unittest_parallel/main.py
@@ -112,7 +112,6 @@ def main(argv=None):
             custom_module = importlib.import_module(args.runner[0])
             args.runner = getattr(custom_module, args.runner[1])
 
-
         # Run the tests in parallel
         start_time = time.perf_counter()
         multiprocessing_context = multiprocessing.get_context(method='spawn')


### PR DESCRIPTION
This PR implements what I suggested on [this issue](https://github.com/craigahobbs/unittest-parallel/issues/19).

Users will be allowed to pass `-r` parameter with custom runner module and class. Here's an example:

![Screenshot 2024-05-20 at 21 05 01](https://github.com/craigahobbs/unittest-parallel/assets/14251739/d69c5d2b-b6c7-4698-912f-be933779f11f)

Since the custom module needs to be specified in the _setup.cfg_ file, the supported package(s) is informed in the _README.md_ file.